### PR TITLE
pgsql and pgsql-multi eclass changes, make deterministic based on use flags

### DIFF
--- a/eclass/postgres-multi.eclass
+++ b/eclass/postgres-multi.eclass
@@ -87,11 +87,10 @@ postgres-multi_forbest() {
 # @DESCRIPTION:
 # Initialize internal environment variable(s).
 postgres-multi_pkg_setup() {
-	local all_slots=$(eselect --brief postgresql list)
 	local user_slot
 
 	for user_slot in "${POSTGRES_COMPAT[@]}"; do
-		has "${user_slot}" ${all_slots} && \
+		use "postgres_${user_slot/\./_}" && \
 			_POSTGRES_UNION_SLOTS+=( "${user_slot}" )
 	done
 

--- a/eclass/postgres.eclass
+++ b/eclass/postgres.eclass
@@ -40,17 +40,22 @@ esac
 if declare -p POSTGRES_COMPAT &> /dev/null ; then
 	# Reverse sort the given POSTGRES_COMPAT so that the most recent
 	# slot is preferred over an older slot.
+	# -- do we care if dependencies are deterministic by USE flags?
 	readarray -t POSTGRES_COMPAT < <(printf '%s\n' "${POSTGRES_COMPAT[@]}" | sort -nr)
 
-	POSTGRES_DEP="|| ("
+	POSTGRES_DEP=""
+	POSTGRES_REQ_USE=" || ("
 	for slot in "${POSTGRES_COMPAT[@]}" ; do
-		POSTGRES_DEP+=" dev-db/postgresql:${slot}="
+		POSTGRES_DEP+=" postgres_${slot/\./_}? ( dev-db/postgresql:${slot}="
 		declare -p POSTGRES_USEDEP &>/dev/null && \
 			POSTGRES_DEP+="[${POSTGRES_USEDEP}]"
+		POSTGRES_DEP+=" )"
+		IUSE+=" postgres_${slot/\./_}"
+		POSTGRES_REQ_USE+=" postgres_${slot/\./_}"
 	done
-	POSTGRES_DEP+=" )"
+	POSTGRES_REQ_USE+=" )"
 else
-	POSTGRES_DEP="dev-db/postgresql"
+	POSTGRES_DEP="dev-db/postgresql:="
 	declare -p POSTGRES_USEDEP &>/dev/null && \
 		POSTGRES_DEP+="[${POSTGRES_USEDEP}]"
 fi


### PR DESCRIPTION
These two commits (as yet untested!!) should convert postgres.eclass and postgres-multi.eclass to handle builds and dependencies determinstically via USE flags rather than through detection of already installed postgres slots on disk.

Control of the dependency list in a multi-postgres package is purely through POSTGRES_COMPAT ; there may be a need for a second variable inside of postgres.eclass that can be used to intersect POSTGRES_COMPAT, so allow for easy dropping of no-longer-available postgres slots -- otherwise if a slot is dropped, all of the packages with said slot in POSTGRES_COMPAT will need to be edited.  Note that there may be dynamic-dependency issues with either or both methods.